### PR TITLE
chore(): add train instructions only with detected objects

### DIFF
--- a/tasks/R2R/env.py
+++ b/tasks/R2R/env.py
@@ -669,7 +669,7 @@ class EnvBatch():
 class R2RBatch():
     ''' Implements the Room to Room navigation task, using discretized viewpoints and pretrained features '''
 
-    def __init__(self, image_features_list, batch_size=100, seed=10, splits=['train'], tokenizer=None, beam_size=1, instruction_limit=None, with_objects=False):
+    def __init__(self, image_features_list, batch_size=100, seed=10, splits=['train'], tokenizer=None, beam_size=1, instruction_limit=None, with_objects=False, train_instructions_with_objects=False):
         self.image_features_list = image_features_list
         self.data = []
         self.scans = []
@@ -702,7 +702,8 @@ class R2RBatch():
         self.batch_size = batch_size
         self._load_nav_graphs()
         self.with_objects = with_objects
-        if with_objects and self.splits == ['train']:
+        self.train_instructions_with_objects = train_instructions_with_objects
+        if with_objects and self.splits in [['train'], ['train_instructions_with_objects']]:
             self._load_objects_by_word()
         self.set_beam_size(beam_size)
         self.print_progress = False
@@ -735,7 +736,10 @@ class R2RBatch():
 
     def _load_objects_by_word(self):
         ''' Load objects that should be en each word (or instruction) '''
-        with open('data/train_objects_by_word.pickle', 'rb') as file:
+        path = 'train_objects_by_word.pickle'
+        if self.train_instructions_with_objects:
+            path = 'train_objects_by_word_with_objects_instructions.pickle'
+        with open(f'data/{path}', 'rb') as file:
             data = pickle.load(file)
 
         print(f'Loading objects of 3 instruction per {len(data.keys())} paths', flush=True)

--- a/tasks/R2R/speaker.py
+++ b/tasks/R2R/speaker.py
@@ -123,7 +123,6 @@ class Seq2SeqSpeaker(object):
     def _score_obs_actions_and_instructions(self, path_obs, path_actions, encoded_instructions, feedback):
         LAMBDA = 0.3
 
-
         assert len(path_obs) == len(path_actions)
         assert len(path_obs) == len(encoded_instructions)
         start_obs, batched_image_features, batched_action_embeddings, path_mask, \
@@ -132,7 +131,7 @@ class Seq2SeqSpeaker(object):
                 path_obs, path_actions, encoded_instructions)
 
         instr_seq, _, _ = batch_instructions_from_encoded(encoded_instructions, self.instruction_len)
-        if self.env.with_objects and self.env.splits == ['train']:
+        if self.env.with_objects and self.env.splits in [['train'], ['train_instructions_with_objects']]:
             objects_seq = self.batch_objects_by_word(path_obs, instr_seq, self.instruction_len)
             number_of_objects_by_word = objects_seq.size(dim=0)
 
@@ -187,7 +186,7 @@ class Seq2SeqSpeaker(object):
             sequence_scores += word_scores.data
             loss += F.nll_loss(log_probs, target, ignore_index=vocab_pad_idx, reduce=True, size_average=True)
 
-            if self.env.with_objects and self.env.splits == ['train']:
+            if self.env.with_objects and self.env.splits in [['train'], ['train_instructions_with_objects']]:
                 for object_idx in range(number_of_objects_by_word):
                     object_target = objects_seq[object_idx, :, t].contiguous()
                     loss += LAMBDA * F.nll_loss(log_probs, object_target, ignore_index=vocab_pad_idx, reduce=True, size_average=True)

--- a/tasks/R2R/train_speaker.py
+++ b/tasks/R2R/train_speaker.py
@@ -197,7 +197,9 @@ def make_env_and_models(args, train_vocab_path, train_splits, test_splits,
     vocab = read_vocab(train_vocab_path)
     tok = Tokenizer(vocab=vocab)
     train_env = R2RBatch(image_features_list, batch_size=batch_size,
-                         splits=train_splits, tokenizer=tok, with_objects=args.with_objects)
+                         splits=train_splits, tokenizer=tok,
+                         with_objects=args.with_objects,
+                         train_instructions_with_objects=args.train_instructions_with_objects)
 
     enc_hidden_size = hidden_size//2 if bidirectional else hidden_size
     glove = np.load(glove_path)
@@ -212,7 +214,8 @@ def make_env_and_models(args, train_vocab_path, train_splits, test_splits,
     test_envs = {
         split: (R2RBatch(image_features_list, batch_size=batch_size,
                          splits=[split], tokenizer=tok,
-                         instruction_limit=test_instruction_limit, with_objects=args.with_objects),
+                         instruction_limit=test_instruction_limit,
+                         with_objects=args.with_objects),
                 eval_speaker.SpeakerEvaluation(
                     [split], instructions_per_path=test_instruction_limit))
         for split in test_splits}
@@ -221,7 +224,12 @@ def make_env_and_models(args, train_vocab_path, train_splits, test_splits,
 
 
 def train_setup(args):
-    train_splits = ['train']
+    if args.train_instructions_with_objects:
+        print("Using train instructions with only objects present", flush=True)
+        train_splits = ['train_instructions_with_objects']
+    else:
+        print("Using all train instructions", flush=True)
+        train_splits = ['train']
     # val_splits = ['train_subset', 'val_seen', 'val_unseen']
     val_splits = ['val_seen', 'val_unseen']
     vocab = TRAIN_VOCAB
@@ -284,6 +292,7 @@ def make_arg_parser():
     parser.add_argument("--snapshot_dir", default=SNAPSHOT_DIR)
     parser.add_argument("--plot_dir", default=PLOT_DIR)
     parser.add_argument("--with_objects", action='store_true')
+    parser.add_argument("--train_instructions_with_objects", action='store_true')
     return parser
 
 

--- a/train_metadata.py
+++ b/train_metadata.py
@@ -7,7 +7,7 @@ import pickle
 MAX_OBJECTS_BY_SEGMENT = 5
 FORBIDDEN_WORDS = ['doorframe', 'light', 'floor', 'ceiling', 'remove', 'otherroom']
 
-with open('data/working_data/train_metadata.pickle', 'rb') as file:
+with open('data/working_data/train_metadata_only_objects_present.pickle', 'rb') as file:
   data = pickle.load(file)
 
 """
@@ -85,6 +85,6 @@ for key, value in data.items():
     )
   processed_data[key] = instruction_objects_by_word
 
-with open('data/train_objects_by_word.pickle', 'wb') as file:
+with open('data/working_data/train_metadata_objects_only.pickle', 'wb') as file:
   pickle.dump(processed_data, file)
 


### PR DESCRIPTION
Will train a sequenced models:

First, only instructions that have detected objects and are used in instructions.
Then, fine-tune with all data.

I add the flag for making that optional.